### PR TITLE
Kwargs updates

### DIFF
--- a/src/elementembeddings/plotter.py
+++ b/src/elementembeddings/plotter.py
@@ -94,7 +94,8 @@ def dimension_plotter(
     n_components: int = 2,
     reducer: str = "umap",
     adjusttext: bool = True,
-    **kwargs,
+    reducer_params: Optional[dict] = None,
+    scatter_params: Optional[dict] = None,
 ):
     """Plot the reduced dimensions of the embeddings.
 
@@ -104,10 +105,14 @@ def dimension_plotter(
         n_components (int): The number of components to reduce to, by default 2
         reducer (str): The dimensionality reduction algorithm to use, by default "umap"
         adjust_text (bool): Whether to avoid overlap of the text labels, by default True
-        **kwargs:  Additional keyword arguments to pass to the
-          dimensionality reduction algorithm.
+        reducer_params (dict, optional): Additional keyword arguments to pass to
+        the reducer, by default None
+        scatter_params (dict, optional): Additional keyword arguments to pass to
+        the scatterplot, by default None
 
     """
+    if reducer_params is None:
+        reducer_params = {}
     if reducer == "umap":
         if (
             embedding._umap_data is not None
@@ -115,7 +120,9 @@ def dimension_plotter(
         ):
             reduced = embedding._umap_data
         else:
-            reduced = embedding.calculate_UMAP(n_components=n_components, **kwargs)
+            reduced = embedding.calculate_UMAP(
+                n_components=n_components, **reducer_params
+            )
     elif reducer == "tsne":
         if (
             embedding._tsne_data is not None
@@ -123,7 +130,9 @@ def dimension_plotter(
         ):
             reduced = embedding._tsne_data
         else:
-            reduced = embedding.calculate_tSNE(n_components=n_components, **kwargs)
+            reduced = embedding.calculate_tSNE(
+                n_components=n_components, **reducer_params
+            )
     elif reducer == "pca":
         if (
             embedding._pca_data is not None
@@ -131,7 +140,9 @@ def dimension_plotter(
         ):
             reduced = embedding._pca_data
         else:
-            reduced = embedding.calculate_PC(n_components=n_components, **kwargs)
+            reduced = embedding.calculate_PC(
+                n_components=n_components, **reducer_params
+            )
     else:
         raise ValueError("Unrecognised reducer.")
 
@@ -146,7 +157,9 @@ def dimension_plotter(
         )
         if not ax:
             fig, ax = plt.subplots()
-        sns.scatterplot(data=df, x="x", y="y", hue="Group", ax=ax, **kwargs)
+        if scatter_params is None:
+            scatter_params = {}
+        sns.scatterplot(data=df, x="x", y="y", hue="Group", ax=ax, **scatter_params)
         ax.set_xlabel("Dimension 1")
         ax.set_ylabel("Dimension 2")
         texts = [

--- a/src/elementembeddings/tests/test_plotter.py
+++ b/src/elementembeddings/tests/test_plotter.py
@@ -96,3 +96,37 @@ class DimensionTest(unittest.TestCase):
             n_components=4,
             reducer="pca",
         )
+
+    def test_kwargs_plotter(self):
+        """Test that the dimension_plotter function works with kwargs."""
+        pca_params = {"svd_solver": "full", "random_state": 42}
+        tsne_params = {"n_iter": 1000, "random_state": 42, "perplexity": 100}
+        umap_params = {"n_neighbors": 15, "random_state": 42}
+        scatter_params = {"s": 1}
+        skipatom_pca_plot = dimension_plotter(
+            self.test_skipatom,
+            n_components=2,
+            reducer="pca",
+            adjusttext=False,
+            reducer_params=pca_params,
+            scatter_params=scatter_params,
+        )
+        assert isinstance(skipatom_pca_plot, plt.Axes)
+        skipatom_tsne_plot = dimension_plotter(
+            self.test_skipatom,
+            n_components=2,
+            reducer="tsne",
+            adjusttext=False,
+            scatter_params=scatter_params,
+            reducer_params=tsne_params,
+        )
+        assert isinstance(skipatom_tsne_plot, plt.Axes)
+        skipatom_umap_plot = dimension_plotter(
+            self.test_skipatom,
+            n_components=2,
+            reducer="umap",
+            adjusttext=False,
+            scatter_params=scatter_params,
+            reducer_params=umap_params,
+        )
+        assert isinstance(skipatom_umap_plot, plt.Axes)


### PR DESCRIPTION
# Dimension plotter kwargs bug

## Description
* Replaced `**kwargs` in `dimension_plotter` with `reducer_params` and `scatter_params` to enable users to supply kwargs  separately to the chosen reducer and the underlying `seaborn.heatmap`.

Fixes #68 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

* Ran `pytest` to check changes do not break the unit tests
* Added new tests to check that the keyword argument `reducer_params` works with the `dimension_plotter` object.

**Test Configuration**:
* Python version: 3.9
* Operating System: WSL2(Ubuntu)


## Reviewers
N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
