### PR TITLE
fix: Resolve lint errors from newer ruff releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ ignore = [
     "PLR0912", # Too many branches
     "PLR0913", # Too many arguments
     "PLR0915", # Too many statements
+    "PLR0917", # Too many positional arguments
     "PLR2004", # Magic-value-comparison TODO fix these
     "PLW2901", # Outer for loop variable overwritten by inner assignment target
     "PLW0603", # Using the global statement to update `_el_ox_states_wiki` is discouraged TODO fix these

--- a/src/elementembeddings/utils/config.py
+++ b/src/elementembeddings/utils/config.py
@@ -31,282 +31,330 @@ DEFAULT_SPECIES_EMBEDDINGS = {
 }
 CITATIONS = {
     "magpie": [
-        "@article{ward2016general,"
-        "title={A general-purpose machine learning framework for "
-        "predicting properties of inorganic materials},"
-        "author={Ward, Logan and Agrawal, Ankit and Choudhary, Alok "
-        "and Wolverton, Christopher},"
-        "journal={npj Computational Materials},"
-        "volume={2},"
-        "number={1},"
-        "pages={1--7},"
-        "year={2016},"
-        "publisher={Nature Publishing Group}}",
+        (
+            "@article{ward2016general,"
+            "title={A general-purpose machine learning framework for "
+            "predicting properties of inorganic materials},"
+            "author={Ward, Logan and Agrawal, Ankit and Choudhary, Alok "
+            "and Wolverton, Christopher},"
+            "journal={npj Computational Materials},"
+            "volume={2},"
+            "number={1},"
+            "pages={1--7},"
+            "year={2016},"
+            "publisher={Nature Publishing Group}}"
+        ),
     ],
     "magpie_sc": [
-        "@article{ward2016general,"
-        "title={A general-purpose machine learning framework for "
-        "predicting properties of inorganic materials},"
-        "author={Ward, Logan and Agrawal, Ankit and Choudhary, Alok "
-        "and Wolverton, Christopher},"
-        "journal={npj Computational Materials},"
-        "volume={2},"
-        "number={1},"
-        "pages={1--7},"
-        "year={2016},"
-        "publisher={Nature Publishing Group}}",
+        (
+            "@article{ward2016general,"
+            "title={A general-purpose machine learning framework for "
+            "predicting properties of inorganic materials},"
+            "author={Ward, Logan and Agrawal, Ankit and Choudhary, Alok "
+            "and Wolverton, Christopher},"
+            "journal={npj Computational Materials},"
+            "volume={2},"
+            "number={1},"
+            "pages={1--7},"
+            "year={2016},"
+            "publisher={Nature Publishing Group}}"
+        ),
     ],
     "mat2vec": [
-        "@article{tshitoyan2019unsupervised,"
-        "title={Unsupervised word embeddings capture latent knowledge "
-        "from materials science literature},"
-        "author={Tshitoyan, Vahe and Dagdelen, John and Weston, Leigh "
-        "and Dunn, Alexander and Rong, Ziqin and Kononova, Olga "
-        "and Persson, Kristin A and Ceder, Gerbrand and Jain, Anubhav},"
-        "journal={Nature},"
-        "volume={571},"
-        "number={7763},"
-        "pages={95--98},"
-        "year={2019},"
-        "publisher={Nature Publishing Group} }",
+        (
+            "@article{tshitoyan2019unsupervised,"
+            "title={Unsupervised word embeddings capture latent knowledge "
+            "from materials science literature},"
+            "author={Tshitoyan, Vahe and Dagdelen, John and Weston, Leigh "
+            "and Dunn, Alexander and Rong, Ziqin and Kononova, Olga "
+            "and Persson, Kristin A and Ceder, Gerbrand and Jain, Anubhav},"
+            "journal={Nature},"
+            "volume={571},"
+            "number={7763},"
+            "pages={95--98},"
+            "year={2019},"
+            "publisher={Nature Publishing Group} }"
+        ),
     ],
     "matscholar": [
-        "@article{weston2019named,"
-        "title={Named entity recognition and normalization applied to "
-        "large-scale information extraction from the materials "
-        "science literature},"
-        "author={Weston, Leigh and Tshitoyan, Vahe and Dagdelen, John and "
-        "Kononova, Olga and Trewartha, Amalie and Persson, Kristin A and "
-        "Ceder, Gerbrand and Jain, Anubhav},"
-        "journal={Journal of chemical information and modeling},"
-        "volume={59},"
-        "number={9},"
-        "pages={3692--3702},"
-        "year={2019},"
-        "publisher={ACS Publications} }",
+        (
+            "@article{weston2019named,"
+            "title={Named entity recognition and normalization applied to "
+            "large-scale information extraction from the materials "
+            "science literature},"
+            "author={Weston, Leigh and Tshitoyan, Vahe and Dagdelen, John and "
+            "Kononova, Olga and Trewartha, Amalie and Persson, Kristin A and "
+            "Ceder, Gerbrand and Jain, Anubhav},"
+            "journal={Journal of chemical information and modeling},"
+            "volume={59},"
+            "number={9},"
+            "pages={3692--3702},"
+            "year={2019},"
+            "publisher={ACS Publications} }"
+        ),
     ],
     "megnet16": [
-        "@article{chen2019graph,"
-        "title={Graph networks as a universal machine learning framework "
-        "for molecules and crystals},"
-        "author={Chen, Chi and Ye, Weike and Zuo, Yunxing and "
-        "Zheng, Chen and Ong, Shyue Ping},"
-        "journal={Chemistry of Materials},"
-        "volume={31},"
-        "number={9},"
-        "pages={3564--3572},"
-        "year={2019},"
-        "publisher={ACS Publications} }",
+        (
+            "@article{chen2019graph,"
+            "title={Graph networks as a universal machine learning framework "
+            "for molecules and crystals},"
+            "author={Chen, Chi and Ye, Weike and Zuo, Yunxing and "
+            "Zheng, Chen and Ong, Shyue Ping},"
+            "journal={Chemistry of Materials},"
+            "volume={31},"
+            "number={9},"
+            "pages={3564--3572},"
+            "year={2019},"
+            "publisher={ACS Publications} }"
+        ),
     ],
     "oliynyk": [
-        "              @article{oliynyk2016high,"
-        "title={High-throughput machine-learning-driven synthesis "
-        "of full-Heusler compounds},"
-        "author={Oliynyk, Anton O and Antono, Erin and Sparks, Taylor D and "
-        "Ghadbeigi, Leila and Gaultois, Michael W and "
-        "Meredig, Bryce and Mar, Arthur},"
-        "journal={Chemistry of Materials},"
-        "volume={28},"
-        "number={20},"
-        "pages={7324--7331},"
-        "year={2016},"
-        "publisher={ACS Publications} }",
+        (
+            "              @article{oliynyk2016high,"
+            "title={High-throughput machine-learning-driven synthesis "
+            "of full-Heusler compounds},"
+            "author={Oliynyk, Anton O and Antono, Erin and Sparks, Taylor D and "
+            "Ghadbeigi, Leila and Gaultois, Michael W and "
+            "Meredig, Bryce and Mar, Arthur},"
+            "journal={Chemistry of Materials},"
+            "volume={28},"
+            "number={20},"
+            "pages={7324--7331},"
+            "year={2016},"
+            "publisher={ACS Publications} }"
+        ),
     ],
     "oliynyk_sc": [
-        "              @article{oliynyk2016high,"
-        "title={High-throughput machine-learning-driven synthesis "
-        "of full-Heusler compounds},"
-        "author={Oliynyk, Anton O and Antono, Erin and Sparks, Taylor D and "
-        "Ghadbeigi, Leila and Gaultois, Michael W and "
-        "Meredig, Bryce and Mar, Arthur},"
-        "journal={Chemistry of Materials},"
-        "volume={28},"
-        "number={20},"
-        "pages={7324--7331},"
-        "year={2016},"
-        "publisher={ACS Publications} }",
+        (
+            "              @article{oliynyk2016high,"
+            "title={High-throughput machine-learning-driven synthesis "
+            "of full-Heusler compounds},"
+            "author={Oliynyk, Anton O and Antono, Erin and Sparks, Taylor D and "
+            "Ghadbeigi, Leila and Gaultois, Michael W and "
+            "Meredig, Bryce and Mar, Arthur},"
+            "journal={Chemistry of Materials},"
+            "volume={28},"
+            "number={20},"
+            "pages={7324--7331},"
+            "year={2016},"
+            "publisher={ACS Publications} }"
+        ),
     ],
     "skipatom": [
-        "@article{antunes2022distributed,"
-        "title={Distributed representations of atoms and materials "
-        "for machine learning},"
-        "author={Antunes, Luis M and Grau-Crespo, Ricardo and Butler, Keith T},"
-        "journal={npj Computational Materials},"
-        "volume={8},"
-        "number={1},"
-        "pages={1--9},"
-        "year={2022},"
-        "publisher={Nature Publishing Group} }",
+        (
+            "@article{antunes2022distributed,"
+            "title={Distributed representations of atoms and materials "
+            "for machine learning},"
+            "author={Antunes, Luis M and Grau-Crespo, Ricardo and Butler, Keith T},"
+            "journal={npj Computational Materials},"
+            "volume={8},"
+            "number={1},"
+            "pages={1--9},"
+            "year={2022},"
+            "publisher={Nature Publishing Group} }"
+        ),
     ],
     "mod_petti": [
-        "@article{glawe2016optimal,"
-        "title={The optimal one dimensional periodic table: "
-        "a modified Pettifor chemical scale from data mining},"
-        "author={Glawe, Henning and Sanna, Antonio and Gross, "
-        "EKU and Marques, Miguel AL},"
-        "journal={New Journal of Physics},"
-        "volume={18},"
-        "number={9},"
-        "pages={093011},"
-        "year={2016},"
-        "publisher={IOP Publishing} }",
+        (
+            "@article{glawe2016optimal,"
+            "title={The optimal one dimensional periodic table: "
+            "a modified Pettifor chemical scale from data mining},"
+            "author={Glawe, Henning and Sanna, Antonio and Gross, "
+            "EKU and Marques, Miguel AL},"
+            "journal={New Journal of Physics},"
+            "volume={18},"
+            "number={9},"
+            "pages={093011},"
+            "year={2016},"
+            "publisher={IOP Publishing} }"
+        ),
     ],
     "crystallm": [
-        "@article{antunes2023crystal,"
-        "title={Crystal structure generation "
-        "with autoregressive large language modeling},"
-        "author={Antunes, Luis M and Butler, Keith T and Grau-Crespo, Ricardo},"
-        "journal={arXiv preprint arXiv:2307.04340},"
-        "year={2023}}",
+        (
+            "@article{antunes2023crystal,"
+            "title={Crystal structure generation "
+            "with autoregressive large language modeling},"
+            "author={Antunes, Luis M and Butler, Keith T and Grau-Crespo, Ricardo},"
+            "journal={arXiv preprint arXiv:2307.04340},"
+            "year={2023}}"
+        ),
     ],
     "xenonpy": [
-        "@article{liu2021machine,"
-        "title={Machine learning to predict quasicrystals from chemical compositions},"
-        "author={Liu, Chang and Fujita, Erina and "
-        "Katsura, Yukari and Inada, Yuki and Ishikawa, Asuka and "
-        "Tamura, Ryuji and Kimura, Kaoru and Yoshida, Ryo},"
-        "journal={Advanced Materials},"
-        "volume={33},"
-        "number={36},"
-        "pages={2102507},"
-        "year={2021},"
-        "publisher={Wiley Online Library}"
-        "}",
-        "@article{kusaba2022crystal,"
-        "title={Crystal structure prediction with machine "
-        "learning-based element substitution},"
-        "author={Kusaba, Minoru and Liu, Chang and Yoshida, Ryo},"
-        "journal={Computational Materials Science},"
-        "volume={211},"
-        "pages={111496},"
-        "year={2022},"
-        "publisher={Elsevier}"
-        "}",
-        "@article{kusaba2023representation,"
-        "title={Representation of materials by kernel mean embedding},"
-        "author={Kusaba, Minoru and Hayashi, Yoshihiro and "
-        "Liu, Chang and Wakiuchi, Araki and Yoshida, Ryo},"
-        "journal={Physical Review B},"
-        "volume={108},"
-        "number={13},"
-        "pages={134107},"
-        "year={2023},"
-        "publisher={APS}"
-        "}",
+        (
+            "@article{liu2021machine,"
+            "title={Machine learning to predict quasicrystals from chemical compositions},"
+            "author={Liu, Chang and Fujita, Erina and "
+            "Katsura, Yukari and Inada, Yuki and Ishikawa, Asuka and "
+            "Tamura, Ryuji and Kimura, Kaoru and Yoshida, Ryo},"
+            "journal={Advanced Materials},"
+            "volume={33},"
+            "number={36},"
+            "pages={2102507},"
+            "year={2021},"
+            "publisher={Wiley Online Library}"
+            "}"
+        ),
+        (
+            "@article{kusaba2022crystal,"
+            "title={Crystal structure prediction with machine "
+            "learning-based element substitution},"
+            "author={Kusaba, Minoru and Liu, Chang and Yoshida, Ryo},"
+            "journal={Computational Materials Science},"
+            "volume={211},"
+            "pages={111496},"
+            "year={2022},"
+            "publisher={Elsevier}"
+            "}"
+        ),
+        (
+            "@article{kusaba2023representation,"
+            "title={Representation of materials by kernel mean embedding},"
+            "author={Kusaba, Minoru and Hayashi, Yoshihiro and "
+            "Liu, Chang and Wakiuchi, Araki and Yoshida, Ryo},"
+            "journal={Physical Review B},"
+            "volume={108},"
+            "number={13},"
+            "pages={134107},"
+            "year={2023},"
+            "publisher={APS}"
+            "}"
+        ),
     ],
     "cgnf": [
-        "@article{jang2024synthesizability,"
-        "title={Synthesizability of materials stoichiometry "
-        "using semi-supervised learning},"
-        "author={Jang, Jidon and Noh, Juhwan and Zhou, Lan "
-        "and Gu, Geun Ho and Gregoire, John M and Jung, Yousung},"
-        "journal={Matter},"
-        "volume={7},"
-        "number={6},"
-        "pages={2294--2312},"
-        "year={2024}",
+        (
+            "@article{jang2024synthesizability,"
+            "title={Synthesizability of materials stoichiometry "
+            "using semi-supervised learning},"
+            "author={Jang, Jidon and Noh, Juhwan and Zhou, Lan "
+            "and Gu, Geun Ho and Gregoire, John M and Jung, Yousung},"
+            "journal={Matter},"
+            "volume={7},"
+            "number={6},"
+            "pages={2294--2312},"
+            "year={2024}"
+        ),
     ],
     "mace_mp0": [
-        "@article{batatia2024foundation,"
-        "title={A foundation model for atomistic materials chemistry},"
-        "author={Batatia, Ilyes and Benner, Philipp and Chiang, Yuan "
-        "and Elena, Alin M. and Kov{\\'a}cs, D{\\'a}vid P. "
-        "and Riebesell, Janosh and others},"
-        "journal={arXiv preprint arXiv:2401.00096},"
-        "year={2024}}",
+        (
+            "@article{batatia2024foundation,"
+            "title={A foundation model for atomistic materials chemistry},"
+            "author={Batatia, Ilyes and Benner, Philipp and Chiang, Yuan "
+            "and Elena, Alin M. and Kov{\\'a}cs, D{\\'a}vid P. "
+            "and Riebesell, Janosh and others},"
+            "journal={arXiv preprint arXiv:2401.00096},"
+            "year={2024}}"
+        ),
     ],
     "sevennet": [
-        "@article{park2024scalable,"
-        "title={Scalable parallel algorithm for graph neural network "
-        "interatomic potentials in molecular dynamics simulations},"
-        "author={Park, Yutack and Kim, Jaesun and Hwang, Seungwoo "
-        "and Han, Seungwu},"
-        "journal={arXiv preprint arXiv:2402.03789},"
-        "year={2024}}",
+        (
+            "@article{park2024scalable,"
+            "title={Scalable parallel algorithm for graph neural network "
+            "interatomic potentials in molecular dynamics simulations},"
+            "author={Park, Yutack and Kim, Jaesun and Hwang, Seungwoo "
+            "and Han, Seungwu},"
+            "journal={arXiv preprint arXiv:2402.03789},"
+            "year={2024}}"
+        ),
     ],
     "orb_v2": [
-        "@article{neumann2024orb,"
-        "title={ORB: A Fast, Scalable Neural Network Potential},"
-        "author={Neumann, Mark and Gin, James and Rhodes, Benjamin "
-        "and Bennett, Steven and Li, Zhiyi and Choubisa, Hitarth "
-        "and Hussey, Arthur and Godwin, Jonathan},"
-        "journal={arXiv preprint arXiv:2410.22570},"
-        "year={2024}}",
+        (
+            "@article{neumann2024orb,"
+            "title={ORB: A Fast, Scalable Neural Network Potential},"
+            "author={Neumann, Mark and Gin, James and Rhodes, Benjamin "
+            "and Bennett, Steven and Li, Zhiyi and Choubisa, Hitarth "
+            "and Hussey, Arthur and Godwin, Jonathan},"
+            "journal={arXiv preprint arXiv:2410.22570},"
+            "year={2024}}"
+        ),
     ],
     "chgnet": [
-        "@article{deng2023chgnet,"
-        "title={{CHGNet} as a pretrained universal neural network potential "
-        "for charge-informed atomistic modelling},"
-        "author={Deng, Bowen and Zhong, Peichen and Jun, KyuJung and "
-        "Riebesell, Janosh and Han, Kevin and Bartel, Christopher J "
-        "and Ceder, Gerbrand},"
-        "journal={Nature Machine Intelligence},"
-        "volume={5},"
-        "number={9},"
-        "pages={1031--1041},"
-        "year={2023},"
-        "publisher={Nature Publishing Group}}",
+        (
+            "@article{deng2023chgnet,"
+            "title={{CHGNet} as a pretrained universal neural network potential "
+            "for charge-informed atomistic modelling},"
+            "author={Deng, Bowen and Zhong, Peichen and Jun, KyuJung and "
+            "Riebesell, Janosh and Han, Kevin and Bartel, Christopher J "
+            "and Ceder, Gerbrand},"
+            "journal={Nature Machine Intelligence},"
+            "volume={5},"
+            "number={9},"
+            "pages={1031--1041},"
+            "year={2023},"
+            "publisher={Nature Publishing Group}}"
+        ),
     ],
     "matscibert": [
-        "@article{gupta2022matscibert,"
-        "title={{MatSciBERT}: A materials domain language model for text "
-        "mining and information extraction},"
-        "author={Gupta, Tanishq and Zaki, Mohd and Krishnan, NM Anoop "
-        "and Mausam},"
-        "journal={npj Computational Materials},"
-        "volume={8},"
-        "number={1},"
-        "pages={102},"
-        "year={2022},"
-        "publisher={Nature Publishing Group}}",
+        (
+            "@article{gupta2022matscibert,"
+            "title={{MatSciBERT}: A materials domain language model for text "
+            "mining and information extraction},"
+            "author={Gupta, Tanishq and Zaki, Mohd and Krishnan, NM Anoop "
+            "and Mausam},"
+            "journal={npj Computational Materials},"
+            "volume={8},"
+            "number={1},"
+            "pages={102},"
+            "year={2022},"
+            "publisher={Nature Publishing Group}}"
+        ),
     ],
     "chemeleon": [
-        "@article{park2025chemeleon,"
-        "title={Crystal structure generation and property optimization "
-        "using a generative graph neural network},"
-        "author={Park, Hyunsoo and Onwuli, Anthony O. and Walsh, Aron},"
-        "journal={Nature Communications},"
-        "volume={16},"
-        "pages={4869},"
-        "year={2025},"
-        "doi={10.1038/s41467-025-59636-y},"
-        "publisher={Nature Publishing Group}}",
+        (
+            "@article{park2025chemeleon,"
+            "title={Crystal structure generation and property optimization "
+            "using a generative graph neural network},"
+            "author={Park, Hyunsoo and Onwuli, Anthony O. and Walsh, Aron},"
+            "journal={Nature Communications},"
+            "volume={16},"
+            "pages={4869},"
+            "year={2025},"
+            "doi={10.1038/s41467-025-59636-y},"
+            "publisher={Nature Publishing Group}}"
+        ),
     ],
     "skipspecies": [
-        "@article{Onwuli_Butler_Walsh_2024, "
-        "title={Ionic species representations for materials informatics}, "
-        "DOI={10.26434/chemrxiv-2024-8621l}, "
-        "journal={ChemRxiv}, "
-        "author={Onwuli, Anthony and Butler, Keith T. and Walsh, Aron}, year={2024}} "
-        "This content is a preprint and has not been peer-reviewed.",
-        "@article{antunes2022distributed,"
-        "title={Distributed representations of atoms and materials "
-        "for machine learning},"
-        "author={Antunes, Luis M and Grau-Crespo, Ricardo and Butler, Keith T},"
-        "journal={npj Computational Materials},"
-        "volume={8},"
-        "number={1},"
-        "pages={1--9},"
-        "year={2022},"
-        "publisher={Nature Publishing Group} }",
+        (
+            "@article{Onwuli_Butler_Walsh_2024, "
+            "title={Ionic species representations for materials informatics}, "
+            "DOI={10.26434/chemrxiv-2024-8621l}, "
+            "journal={ChemRxiv}, "
+            "author={Onwuli, Anthony and Butler, Keith T. and Walsh, Aron}, year={2024}} "
+            "This content is a preprint and has not been peer-reviewed."
+        ),
+        (
+            "@article{antunes2022distributed,"
+            "title={Distributed representations of atoms and materials "
+            "for machine learning},"
+            "author={Antunes, Luis M and Grau-Crespo, Ricardo and Butler, Keith T},"
+            "journal={npj Computational Materials},"
+            "volume={8},"
+            "number={1},"
+            "pages={1--9},"
+            "year={2022},"
+            "publisher={Nature Publishing Group} }"
+        ),
     ],
     "skipspecies_induced": [
-        "@article{Onwuli_Butler_Walsh_2024, "
-        "title={Ionic species representations for materials informatics}, "
-        "DOI={10.26434/chemrxiv-2024-8621l}, "
-        "journal={ChemRxiv}, "
-        "author={Onwuli, Anthony and Butler, Keith T. and Walsh, Aron}, year={2024}} "
-        "This content is a preprint and has not been peer-reviewed.",
-        "@article{antunes2022distributed,"
-        "title={Distributed representations of atoms and materials "
-        "for machine learning},"
-        "author={Antunes, Luis M and Grau-Crespo, Ricardo and Butler, Keith T},"
-        "journal={npj Computational Materials},"
-        "volume={8},"
-        "number={1},"
-        "pages={1--9},"
-        "year={2022},"
-        "publisher={Nature Publishing Group} }",
+        (
+            "@article{Onwuli_Butler_Walsh_2024, "
+            "title={Ionic species representations for materials informatics}, "
+            "DOI={10.26434/chemrxiv-2024-8621l}, "
+            "journal={ChemRxiv}, "
+            "author={Onwuli, Anthony and Butler, Keith T. and Walsh, Aron}, year={2024}} "
+            "This content is a preprint and has not been peer-reviewed."
+        ),
+        (
+            "@article{antunes2022distributed,"
+            "title={Distributed representations of atoms and materials "
+            "for machine learning},"
+            "author={Antunes, Luis M and Grau-Crespo, Ricardo and Butler, Keith T},"
+            "journal={npj Computational Materials},"
+            "volume={8},"
+            "number={1},"
+            "pages={1--9},"
+            "year={2022},"
+            "publisher={Nature Publishing Group} }"
+        ),
     ],
 }
 


### PR DESCRIPTION
## Summary

The `qa` job currently fails on every PR (e.g. #198) with 26 ruff errors. Ruff is unpinned (`ruff>=0.15.21`), so CI resolves the latest release each run, and recent ruff releases stabilised two rules that flag existing code:

- **ISC004** (24 errors): implicit string concatenations inside the `CITATIONS` lists in `utils/config.py`. Fixed by parenthesising them (ruff auto-fix). The string values are byte-for-byte unchanged — verified by hashing `CITATIONS` before and after.
- **PLR0917** "too many positional arguments" (2 errors in `plotter.py`): added to the ignore list, consistent with the other PLR09xx complexity rules (PLR0911/0912/0913/0915) already ignored.

## Testing

- `ruff check` passes on both ruff 0.16.2 (what CI resolves today) and the locked 0.15.x
- `prek run --all-files` passes (all qa hooks)
- `CITATIONS` sha256 identical before/after

Unblocks #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved the formatting and readability of citation information without changing its content.

- **Chores**
  - Updated code quality configuration to better accommodate existing project patterns.
  - No user-facing functionality or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->